### PR TITLE
Bumped Node / Alpine for Security Fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8-alpine
+FROM node:8.11.3-alpine
 
 COPY package.json ./
 


### PR DESCRIPTION
Looks like node:8.11.3-alpine is the latest version including security fixes up through June, 2018