### PR TITLE
fix reading credentials from file by setting proper encoding

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const unleash = require('unleash-server');
 let options = {};
 
 if (process.env.DATABASE_URL_FILE) {
-    options.databaseUrl = fs.readFileSync(process.env.DATABASE_URL_FILE);
+    options.databaseUrl = fs.readFileSync(process.env.DATABASE_URL_FILE, {encoding: 'utf8'});
 }
 
 unleash.start(options);

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const unleash = require('unleash-server');
 let options = {};
 
 if (process.env.DATABASE_URL_FILE) {
-    options.databaseUrl = fs.readFileSync(process.env.DATABASE_URL_FILE, {encoding: 'utf8'});
+    options.databaseUrl = fs.readFileSync(process.env.DATABASE_URL_FILE, 'utf8');
 }
 
 unleash.start(options);


### PR DESCRIPTION
without specifying the encoding readFileSync will return a Buffer instead of a string which crashes unleash.

Concretely I got:
```
Failed to migrate db TypeError: Parameter "url" must be a string, not object
    at Url.parse (url.js:103:11)
    at Object.urlParse [as parse] (url.js:97:13)
    at module.exports (/node_modules/parse-database-url/lib/parse-database-url.js:16:23)
```