### PR TITLE
Bump postgres, node and docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8-alpine
+FROM node:11-alpine
 
 COPY package.json ./
 

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ $ docker-compose up
 ```
 
 ### Requirements
-We are using docker-compose version 3.3 and it requires:
+We are using docker-compose version 3.7 and it requires:
 
-- Docker engine 17.06.0+
-- Docker compose 1.14.0+
+- Docker engine 18.06.0+
+- Docker compose 1.22.0+
 
 For more info, check out the compatibility matrix on Docker's website: [compatibility-matrix](
 https://docs.docker.com/compose/compose-file/compose-versioning/#compatibility-matrix)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.3"
+version: "3.7"
 services:
   web:
     build: .
@@ -18,4 +18,4 @@ services:
   db:
     expose:
       - "5432"
-    image: postgres:10-alpine
+    image: postgres:11-alpine


### PR DESCRIPTION
Signed-off-by: Rauny Brandão <rauny.brandao@gmail.com>

Bump versions:

- node from 8 to 11
- postgres from 10 to 11
- docker-compose from 3.3 to 3.7

**docker-compose up logs**:

```
Creating network "unleash-docker_default" with the default driver
Pulling db (postgres:11-alpine)...
11-alpine: Pulling from library/postgres
bdf0201b3a05: Pull complete
365f27dc05d7: Pull complete
bf541d40dfbc: Pull complete
823ce70c3252: Pull complete
a92a31ecd32a: Pull complete
83cc8c6d8282: Pull complete
777e556126e8: Pull complete
2c712d007694: Pull complete
4595ea32f49a: Pull complete
Digest: sha256:b93d17a9c65f135172e1f4b4b5a6ed0155f6c32ab1aa5a5fde0b1cdaef728a41
Status: Downloaded newer image for postgres:11-alpine
Building web
Step 1/6 : FROM node:11-alpine
11-alpine: Pulling from library/node
bdf0201b3a05: Already exists
f82315922d4f: Pull complete
e70c14082adc: Pull complete
Digest: sha256:2278992c11ebfba68ca40a56ac77de59f5669b9ce1bb479f89840c95ac1adae7
Status: Downloaded newer image for node:11-alpine
 ---> cd4fae427afc
Step 2/6 : COPY package.json ./
 ---> 83d590704127
Step 3/6 : RUN npm install --production
 ---> Running in dbcbb18581ba

> gc-stats@1.2.1 install /node_modules/gc-stats
> node-pre-gyp install --fallback-to-build

node-pre-gyp WARN Using needle for node-pre-gyp https download 
[gc-stats] Success: "/node_modules/gc-stats/build/gcstats/v1.2.1/Release/node-v67-linux-x64/gcstats.node" is installed via remote
npm notice created a lockfile as package-lock.json. You should commit this file.
npm WARN unleash-docker@ No repository field.

added 493 packages from 314 contributors and audited 1560 packages in 9.504s
found 0 vulnerabilities

Removing intermediate container dbcbb18581ba
 ---> 405d9cb1de83
Step 4/6 : COPY . .
 ---> 13356e6b33dd
Step 5/6 : EXPOSE 4242
 ---> Running in a431700bba2b
Removing intermediate container a431700bba2b
 ---> fc74fdea530a
Step 6/6 : CMD node index.js
 ---> Running in fda341230bb5
Removing intermediate container fda341230bb5
 ---> 8437761f655e

Successfully built 8437761f655e
Successfully tagged unleash-docker_web:latest
WARNING: Image for service web was built because it did not already exist. To rebuild this image you must use `docker-compose build` or `docker-compose up --build`.
Creating unleash-docker_db_1 ... done
Creating unleash-docker_web_1 ... done
Attaching to unleash-docker_db_1, unleash-docker_web_1
db_1   | The files belonging to this database system will be owned by user "postgres".
db_1   | This user must also own the server process.
db_1   | 
web_1  | Postgres is unavailable.
db_1   | The database cluster will be initialized with locale "en_US.utf8".
db_1   | The default database encoding has accordingly been set to "UTF8".
db_1   | The default text search configuration will be set to "english".
db_1   | 
db_1   | Data page checksums are disabled.
db_1   | 
db_1   | fixing permissions on existing directory /var/lib/postgresql/data ... ok
db_1   | creating subdirectories ... ok
db_1   | selecting default max_connections ... 100
db_1   | selecting default shared_buffers ... 128MB
db_1   | selecting dynamic shared memory implementation ... posix
db_1   | creating configuration files ... ok
db_1   | running bootstrap script ... ok
db_1   | performing post-bootstrap initialization ... sh: locale: not found
db_1   | 2019-04-21 20:50:32.341 UTC [26] WARNING:  no usable system locales were found
db_1   | ok
db_1   | syncing data to disk ... ok
db_1   | 
db_1   | Success. You can now start the database server using:
db_1   | 
db_1   |     pg_ctl -D /var/lib/postgresql/data -l logfile start
db_1   | 
db_1   | 
db_1   | WARNING: enabling "trust" authentication for local connections
db_1   | You can change this by editing pg_hba.conf or using the option -A, or
db_1   | --auth-local and --auth-host, the next time you run initdb.
db_1   | ****************************************************
db_1   | WARNING: No password has been set for the database.
db_1   |          This will allow anyone with access to the
db_1   |          Postgres port to access your database. In
db_1   |          Docker's default configuration, this is
db_1   |          effectively any other container on the same
db_1   |          system.
db_1   | 
db_1   |          Use "-e POSTGRES_PASSWORD=password" to set
db_1   |          it in "docker run".
db_1   | ****************************************************
db_1   | waiting for server to start....2019-04-21 20:50:32.777 UTC [31] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
db_1   | 2019-04-21 20:50:32.790 UTC [32] LOG:  database system was shut down at 2019-04-21 20:50:32 UTC
db_1   | 2019-04-21 20:50:32.793 UTC [31] LOG:  database system is ready to accept connections
db_1   |  done
db_1   | server started
db_1   | 
db_1   | /usr/local/bin/docker-entrypoint.sh: ignoring /docker-entrypoint-initdb.d/*
db_1   | 
db_1   | waiting for server to shut down....2019-04-21 20:50:32.873 UTC [31] LOG:  received fast shutdown request
db_1   | 2019-04-21 20:50:32.875 UTC [31] LOG:  aborting any active transactions
db_1   | 2019-04-21 20:50:32.877 UTC [31] LOG:  background worker "logical replication launcher" (PID 38) exited with exit code 1
db_1   | 2019-04-21 20:50:32.877 UTC [33] LOG:  shutting down
db_1   | 2019-04-21 20:50:32.903 UTC [31] LOG:  database system is shut down
db_1   |  done
db_1   | server stopped
db_1   | 
db_1   | PostgreSQL init process complete; ready for start up.
db_1   | 
db_1   | 2019-04-21 20:50:32.995 UTC [1] LOG:  listening on IPv4 address "0.0.0.0", port 5432
db_1   | 2019-04-21 20:50:32.996 UTC [1] LOG:  listening on IPv6 address "::", port 5432
db_1   | 2019-04-21 20:50:33.000 UTC [1] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
db_1   | 2019-04-21 20:50:33.028 UTC [40] LOG:  database system was shut down at 2019-04-21 20:50:32 UTC
db_1   | 2019-04-21 20:50:33.031 UTC [1] LOG:  database system is ready to accept connections
db_1   | 2019-04-21 20:50:33.436 UTC [47] LOG:  incomplete startup packet
web_1  | 
web_1  | > unleash-docker@ start /
web_1  | > NODE_ENV=production unleash
web_1  | 
web_1  | Unleash started on http://:::4242
```

**Trying to add a new feature toggle**:

![image](https://user-images.githubusercontent.com/13734862/56475404-30cdae00-645e-11e9-83fd-e498ac01e127.png)

**API**:

```
curl localhost:4242/api/features/
{"version":1,"features":[{"name":"test","description":"test","enabled":true,"strategies":[{"name":"default","parameters":{}}],"variants":null,"createdAt":"2019-04-21T20:51:38.748Z"}]}
```