### PR TITLE
Define healthchecks

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ $ docker-compose up
 ```
 
 ### Requirements
-We are using docker-compose version 3.3 and it requires:
+We are using docker-compose version 3.4 and it requires:
 
-- Docker engine 17.06.0+
-- Docker compose 1.14.0+
+- Docker engine 17.09.0+
+- Docker compose 1.17.0+
 
 For more info, check out the compatibility matrix on Docker's website: [compatibility-matrix](
 https://docs.docker.com/compose/compose-file/compose-versioning/#compatibility-matrix)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,13 +8,13 @@ services:
       DATABASE_URL: postgres://postgres:unleash@db/postgres
     depends_on:
       - db
-    command: > 
-      sh -c "
-        while ! nc -z db 5432; do
-          echo 'Postgres is unavailable.'
-          sleep 1
-        done
-        npm run start"
+    command: npm run start
+    healthcheck:
+      test: ["CMD", "nc",  "-z", "db", "5432"]
+      interval: 1s
+      timeout: 1m
+      retries: 5
+      start_period: 15s
   db:
     expose:
       - "5432"
@@ -22,3 +22,9 @@ services:
     environment:
       POSTGRES_DB: "db"
       POSTGRES_HOST_AUTH_METHOD: "trust"
+    healthcheck:
+      test: ["CMD", "pg_isready", "--username=postgres", "--host=127.0.0.1", "--port=5432"]
+      interval: 2s
+      timeout: 1m
+      retries: 5
+      start_period: 10s


### PR DESCRIPTION
💁 Docker Compose natively supports per service [healthcheck](https://docs.docker.com/compose/compose-file/#healthcheck)s. Defining one for each means that the command is simplified and Docker Compose will also report on the health of each service after starting it.