### PR TITLE
chore: Setup GHA to perform our publishes to Docker

### DIFF
--- a/.github/workflows/build_latest.yml
+++ b/.github/workflows/build_latest.yml
@@ -1,0 +1,26 @@
+name: Build and publish latest
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
+      - name: npm
+        run: npm install
+      - name: Login to docker hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build & publish latest
+        run: yes | npm run docker:publish-latest
+

--- a/.github/workflows/push_tags_to_docker.yml
+++ b/.github/workflows/push_tags_to_docker.yml
@@ -1,0 +1,26 @@
+name: Push Tags
+
+on:
+  push:
+    tags:
+      - '\d+\.\d+\.\d+'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
+      - name: npm
+        run: npm install
+      - name: Login to docker hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Publish tag
+        run: yes | npm run docker:release-default

--- a/package.json
+++ b/package.json
@@ -7,8 +7,10 @@
     "test:ci": "echo 'no tests for unleash-docker';",
     "docker:build": "./tools/release.js build",
     "docker:build-default": "./tools/release.js build --node-docker-versions 12-alpine,14-alpine --default-node-docker-version 12-alpine",
+    "docker:build-latest": "./tools/release.js build --node-docker-versions 12-alpine,14-alpine --default-node-docker-version 12-alpine --latest",
     "docker:publish": "./tools/release.js publish",
-    "docker:publish-default": "./tools/release.js publish --node-docker-versions 12-alpine,14-alpine --default-node-docker-version 12-alpine"
+    "docker:publish-default": "./tools/release.js publish --node-docker-versions 12-alpine,14-alpine --default-node-docker-version 12-alpine",
+    "docker:publish-latest": "./tools/release.js publish --node-docker-versions 12-alpine,14-alpine --default-node-docker-version 12-alpine --latest"
   },
   "engines": {
     "node": ">=12"

--- a/tools/release.js
+++ b/tools/release.js
@@ -11,12 +11,16 @@ const { buildDockerImages, pushDockerImage } = require('./docker-utils');
 
 async function main() {
   const argv = yargs(hideBin(process.argv))
-    .option('defaultNodeDockerVersion', {
-      alias: 'default-node-docker-version',
-      describe: 'Node Docker version for latest tag',
-      demandOption: true,
-    })
-    .option('nodeDockerVersions', {
+      .option('latest', {
+        describe:
+            'Whether to tag with latest or with version from package.json',
+        default: false,
+        type: 'boolean'
+      }).option('defaultNodeDockerVersion', {
+        alias: 'default-node-docker-version',
+        describe: 'Node Docker version for latest tag',
+        demandOption: true,
+    }).option('nodeDockerVersions', {
       alias: 'node-docker-versions',
       describe:
         'Comma-separated list of Node Docker tag versions (e.g., "12-alpine,14-alpine")',
@@ -34,6 +38,7 @@ async function main() {
         `defaultNodeDockerVersion "${defaultNodeDockerVersion}" was not in list of versions "${nodeDockerVersions}"`,
       );
     })
+
     .command({
       command: 'build',
       desc: 'Build Docker image(s) based on Node version(s)',


### PR DESCRIPTION
Discussed in #36 - Rather than waiting for docker hub to do the builds, we'll use the release tool introduced in that PR to perform releases when tagging, and pushing the latest tag for any commit to master.

This also adds a latest-12-alpine and latest-14-alpine tag for those who really want to live on the edge but still decide their node version :)