### PR TITLE
use workdir and run as non root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,21 @@
+FROM node:12-alpine as builder
+
+WORKDIR /unleash
+
+COPY index.js package.json package-lock.json ./
+
+RUN npm ci
+
 FROM node:12-alpine
 
 ENV NODE_ENV production
 
-COPY package.json package-lock.json ./
+WORKDIR /unleash
 
-RUN npm ci
-
-COPY . .
+COPY --from=builder /unleash /unleash
 
 EXPOSE 4242
+
+USER node
 
 CMD node index.js


### PR DESCRIPTION
Signed-off-by: André Bauer <monotek23@gmail.com>

* adds workdir "/unleash" so app is not installed to "/"
* run app as non root user "node" for security reasons
* use builder pattern to lower image size
* copying only needed stuff to the directory instead of everything (including the git repo) resulting in smaller docker image

