### PR TITLE
Update docker-compose config file version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.3"
+version: "3.4"
 services:
   web:
     build: .


### PR DESCRIPTION
While launching the build via docker-compose, I was greeted by the following error message:

> services.db.healthcheck value Additional properties are not allowed ('start_period' was unexpected)
> services.web.healthcheck value Additional properties are not allowed ('start_period' was unexpected)

After some reading, it appears that the start_period option is available
in docker-compose configuration file since version 3.4. See [here](https://docs.docker.com/compose/compose-file/compose-file-v3/#healthcheck) for more information.