### PR TITLE
fix(release script): support multi-stage builds when rendering Dockerfile

### DIFF
--- a/tools/docker-utils.js
+++ b/tools/docker-utils.js
@@ -13,7 +13,7 @@ const dockerfileTemplate = fs.readFileSync(
   'utf8',
 );
 
-const fromLineRegExp = /FROM node:.*?\n/g;
+const fromStatementRegExp = /FROM node:.*?(\s|\n)/g;
 
 /**
  * Render a Dockerfile with the correct base image.
@@ -23,8 +23,12 @@ const fromLineRegExp = /FROM node:.*?\n/g;
  */
 function renderDockerfile({ nodeDockerVersion }) {
   return dockerfileTemplate.replace(
-    fromLineRegExp,
-    `FROM node:${nodeDockerVersion}`,
+    fromStatementRegExp,
+      // We need a trailing space for the first step(s) in the multi-stage build
+      // (between "FROM node:<version>" and e.g., "as builder").
+      // This also adds a trailing space to the end of the final
+      // FROM statement, but it doesn't make a difference.
+      `FROM node:${nodeDockerVersion} `
   );
 }
 


### PR DESCRIPTION
This adds support to the release script for multi-stage Docker builds by replacing only the `FROM node:<version>` part and adding a space. Required for #39.

I tested this on both the main branch and based on the #39 branch by adding `renderDockerfile` to the module exports of `./tools/docker-utils.js`:

<img src="https://user-images.githubusercontent.com/1404650/110620008-d0060680-8198-11eb-99d2-0235c41ae429.png" width="300px" alt="Render Dockerfile function added to module exports in IDE">

… and then running:

`$ node -p "require('./tools/docker-utils').renderDockerfile({ nodeDockerVersion: '14.0.0' })"`