### PR TITLE
Tag builder only builds node-16.

### DIFF
--- a/.github/workflows/build_on_pr.yml
+++ b/.github/workflows/build_on_pr.yml
@@ -1,4 +1,4 @@
-name: Build and publish latest
+name: Build docker (PR)
 on:
   push:
     branches:

--- a/.github/workflows/push_tags_to_docker.yml
+++ b/.github/workflows/push_tags_to_docker.yml
@@ -8,9 +8,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        version: [14-alpine,16-alpine]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -25,8 +22,8 @@ jobs:
           images: |
             unleashorg/unleash-server
           tags:
-            type=semver,pattern={{ version }},suffix=-${{ matrix.version }}
-            type=semver,pattern={{ major.minor }},suffix=-${{ matrix.version }}
+            type=semver,pattern={{ version }}
+            type=semver,pattern={{ major.minor }}
       - name: Login to docker hub
         uses: docker/login-action@v1
         with:
@@ -39,4 +36,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: NODE_VERSION=${{ matrix.version }}
+          build-args: NODE_VERSION=16-alpine

--- a/.github/workflows/push_tags_to_docker.yml
+++ b/.github/workflows/push_tags_to_docker.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           images: |
             unleashorg/unleash-server
-          tags:
+          tags: |
             type=semver,pattern={{ version }}
             type=semver,pattern={{ major.minor }}
             type=semver,pattern={{major}}


### PR DESCRIPTION
Edge / main builder will still build both version

We have been running unleash node16 in production since January, this drops building 14-alpine altogether for our tagged releases. Due an incorrect configuration, we've been publishing the node version that was last in our matrix, which happened to be 16 anyway, this makes it more explicit.