### PR TITLE
chore: improve healthchecks

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ unleash locally without setting up a database or node.
 $ docker-compose build
 $ docker-compose up
 ```
+On some computers the database won't start in time for unleash the first time you run this. If unleash fails to reach the database, `docker-compose restart web` usually resolves the issue.
 
 ### Requirements
 We are using docker-compose version 3.9 and it requires:

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ unleash locally without setting up a database or node.
 $ docker-compose build
 $ docker-compose up
 ```
-On some computers the database won't start in time for unleash the first time you run this. If unleash fails to reach the database, `docker-compose restart web` usually resolves the issue.
+On some computers the database won't start in time for Unleash the first time you run this. If Unleash fails to reach the database, `docker-compose restart web` usually resolves the issue.
 
 ### Requirements
 We are using docker-compose version 3.9 and it requires:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,7 +88,7 @@ services:
       # trust incoming connections blindly (DON'T DO THIS IN PRODUCTION!)
       POSTGRES_HOST_AUTH_METHOD: "trust"
     healthcheck:
-      test: ["CMD", "pg_isready", "--username=postgres", "--host=127.0.0.1", "--port=5432"]
+      test: ["CMD", "nc",  "-z", "db", "5432"]
       interval: 2s
       timeout: 1m
       retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,12 @@ services:
       UNLEASH_API_TOKEN: "default:development.unleash-insecure-api-token"
     depends_on:
       - web
+    healthcheck:
+      test: wget --no-verbose --tries=1 --spider http://localhost:3000/proxy/health || exit 1
+      interval: 1s
+      timeout: 1m
+      retries: 5
+
 
   # The Unleash server contains the Unleash configuration and
   # communicates with server-side SDKs and the Unleash Proxy
@@ -61,11 +67,13 @@ services:
       # key from `proxy.environment.UNLEASH_PROXY_CLIENT_KEYS`
       # instead.
       INIT_CLIENT_API_TOKENS: "default:development.unleash-insecure-api-token"
+      # Changing log levels:
+      # LOG_LEVEL: "debug"
     depends_on:
       - db
     command: node index.js
     healthcheck:
-      test: ["CMD", "nc",  "-z", "db", "5432"]
+      test: wget --no-verbose --tries=1 --spider http://localhost:4242/health || exit 1
       interval: 1s
       timeout: 1m
       retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,7 +88,7 @@ services:
       # trust incoming connections blindly (DON'T DO THIS IN PRODUCTION!)
       POSTGRES_HOST_AUTH_METHOD: "trust"
     healthcheck:
-      test: ["CMD", "nc",  "-z", "db", "5432"]
+      test: ["CMD", "pg_isready", "--username=postgres", "--host=127.0.0.1", "--port=5432"]
       interval: 2s
       timeout: 1m
       retries: 5


### PR DESCRIPTION
This is initiated by looking at https://github.com/Unleash/unleash/issues/1934

With this patch docker-compose corretly reports the stauts of our three
containers. Can be observed by running `watch -n0.1 docker-compose ps`
while starting the containers using `docker-compose up`.
