### PR TITLE
fix: docker publish minor image

### DIFF
--- a/.github/workflows/push_tags_to_docker.yml
+++ b/.github/workflows/push_tags_to_docker.yml
@@ -23,8 +23,8 @@ jobs:
             unleashorg/unleash-server
           tags: |
             type=semver,pattern={{ version }}
-            type=semver,pattern={{ major.minor }}
-            type=semver,pattern={{major}}
+            type=semver,pattern={{ major }}.{{ minor }}
+            type=semver,pattern={{ major }}
       - name: Login to docker hub
         uses: docker/login-action@v1
         with:


### PR DESCRIPTION
## About the changes
Looking at the documentation: https://github.com/docker/metadata-action#typesemver the format for minor version was not correct.

[Latest action published](https://github.com/Unleash/unleash-docker/runs/7126462514?check_suite_focus=true):
```
Docker tags
  unleashorg/unleash-server:4.13.0
  unleashorg/unleash-server:4
  unleashorg/unleash-server:latest
```

Closes #76 
