### PR TITLE
task: bump version to newest released version of unleash-server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM unleashorg/unleash-server:4.15.1
+FROM unleashorg/unleash-server:4.16.4
 
 COPY wait-for /unleash/


### PR DESCRIPTION
In the interest of keeping our docker-compose file on our newest released version (OSS constraints) this PR updates the FROM source for the Dockerfile we use to setup unleash-server in the compose file.